### PR TITLE
Add repository governance and protections

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# The project owner must review changes anywhere in the repository.
+* @JohnKinyanjui
+
+# Keep ownership and automation policy under the same review boundary.
+/.github/ @JohnKinyanjui
+/GOVERNANCE.md @JohnKinyanjui
+/CONTRIBUTING.md @JohnKinyanjui

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## What changed
+
+Describe the change and why it is needed.
+
+## User impact
+
+Explain what users will notice. Include screenshots or a short recording for visible UI changes.
+
+## Validation
+
+- [ ] `bun run check`
+- [ ] `cargo test --manifest-path src-tauri/Cargo.toml`
+- [ ] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
+- [ ] I tested relevant macOS, Windows, or Linux behavior, or explained why it is not applicable.
+
+## Risk and compatibility
+
+List migrations, file-format changes, security implications, or known limitations. Write `None` when there are none.
+
+## Contributor checklist
+
+- [ ] This pull request has one focused outcome.
+- [ ] I did not include credentials, private workspace data, or unlicensed assets.
+- [ ] I preserved unrelated code and user-authored changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v5
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
+
+      - name: Install frontend dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check frontend
+        run: bun run check
+
+      - name: Test native core
+        run: cargo test --manifest-path src-tauri/Cargo.toml
+
+      - name: Lint native core
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to Sprite Studio
+
+Thank you for helping improve Sprite Studio. Contributions are welcome through focused pull requests that are easy to understand, test, and review.
+
+## Before starting
+
+- Search existing issues and pull requests before opening a duplicate.
+- Open an issue first for large features, architectural changes, new providers, or changes to generated file formats.
+- Keep each pull request focused on one coherent outcome.
+- Never include credentials, private workspace data, generated user assets, or third-party material without a compatible license.
+
+## Development workflow
+
+1. Fork the repository and create a descriptive branch.
+2. Install dependencies with `bun install --frozen-lockfile`.
+3. Make the smallest complete change that solves the problem.
+4. Add or update tests where behavior changes.
+5. Run the required checks:
+
+   ```bash
+   bun run check
+   cargo test --manifest-path src-tauri/Cargo.toml
+   cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+   ```
+
+6. Open a pull request using the repository template and explain the user impact.
+
+## Pull-request expectations
+
+- Describe what changed and why.
+- Include screenshots or short recordings for visible UI changes.
+- Call out migrations, compatibility risks, or platform-specific behavior.
+- Preserve unrelated code and user-authored changes.
+- Respond to review feedback with new commits rather than rewriting shared history during review.
+- Keep generated binaries and local workspace data out of the repository.
+
+All changes remain subject to code-owner review and required automated checks. A merged pull request gives contribution credit but does not grant direct repository access. Maintainer eligibility is described in [GOVERNANCE.md](GOVERNANCE.md).
+
+## Reporting security issues
+
+Do not open a public issue for a vulnerability that could put users or their files at risk. Use GitHub's private vulnerability-reporting flow when it is available for the repository.
+
+## License
+
+By submitting a contribution, you agree that it may be distributed under the repository's MIT license.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,63 @@
+# Sprite Studio governance
+
+Sprite Studio is an open-source project led by John Kinyanjui. Contribution credit and repository authority are intentionally separate: accepted work is credited immediately, while maintainer access is earned through sustained, trusted participation.
+
+## Roles
+
+### Contributor
+
+Anyone whose issue, review, documentation, design, code, or other work improves Sprite Studio is a contributor. A merged commit may appear automatically in GitHub's contributor graph. Contributor status does not grant permission to push, merge, publish releases, manage secrets, or change repository settings.
+
+### Maintainer
+
+Maintainers may review or merge changes within the access explicitly granted to them. Maintainer access is never automatic and remains subject to repository protection rules.
+
+To be considered, a contributor must normally have:
+
+- at least 10 meaningful pull requests merged;
+- at least 90 days of consistent, constructive participation;
+- demonstrated care with testing, security, backwards compatibility, and review feedback;
+- a record of respectful collaboration and sound technical judgment; and
+- explicit approval from the project owner.
+
+These are minimum eligibility signals, not an entitlement to access. Documentation-only count inflation, mechanical changes split across many pull requests, or low-quality submissions do not satisfy the intent of the policy.
+
+Maintainers are expected to:
+
+- protect the product direction and the safety of user data;
+- review changes carefully and disclose conflicts of interest;
+- keep `main` releasable;
+- follow the security and release processes; and
+- step back from privileged access when they are no longer active.
+
+### Code owner
+
+Code owners are trusted maintainers responsible for approving changes in a defined area. The repository-wide code owner is currently `@JohnKinyanjui`.
+
+### Project owner
+
+The project owner has final responsibility for product direction, maintainer appointments, security decisions, repository access, and releases.
+
+## Decision making
+
+Routine improvements are decided through pull-request review. Changes to product direction, security boundaries, supported platforms, release policy, or governance require project-owner approval.
+
+When consensus is not possible, the project owner makes the final decision and documents material reasoning in the relevant issue or pull request.
+
+## Repository access
+
+- External contributors work through forks and pull requests.
+- Merging one or more pull requests does not grant direct push access.
+- Changes to protected branches require the configured reviews and automated checks.
+- Repository and release credentials are limited to the minimum number of trusted maintainers.
+- Access may be reduced or removed for inactivity, compromised credentials, policy violations, or project-safety concerns.
+
+## Credit and releases
+
+GitHub may automatically credit anyone whose authored commits reach the default branch. Sprite Studio does not rewrite valid contribution history merely to change that display.
+
+Release notes are curated around user-facing changes. Individual acknowledgements may be included when they add useful context, but they are separate from maintainer status.
+
+## Changing this policy
+
+Governance changes are proposed through a pull request and require project-owner approval.

--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ SQLite stores project metadata, conversations, worktrees, asset versions, timeli
 
 Sprite Studio `0.2.0` is an early public release. The core desktop workflow works, but file formats, provider adapters, and generation harnesses will continue to evolve.
 
+## Contributing and governance
+
+Contributions are welcome through reviewed pull requests. Read [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow and [GOVERNANCE.md](GOVERNANCE.md) for the distinction between contribution credit, maintainer access, code ownership, and project ownership.
+
 ## License
 
 MIT


### PR DESCRIPTION
## What changed

- Defines contributor, maintainer, code-owner, and project-owner roles.
- Requires 10 meaningful merged pull requests, 90 days of participation, and owner approval before maintainer consideration.
- Assigns repository-wide code ownership to @JohnKinyanjui.
- Adds a focused contribution guide and pull-request template.
- Adds pull-request CI for Svelte checks, Rust tests, and Clippy.
- Links the policies from the README.

## Why

Automatic contributor credit should remain separate from trusted repository access. This makes that distinction explicit and creates enforceable review and quality gates for future contributions.

## Validation

- `bun run check`
- `cargo test --manifest-path src-tauri/Cargo.toml` — 59 passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- Workflow YAML parsed locally.